### PR TITLE
Improving TOP requirements and changing documentation URL

### DIFF
--- a/Multiplex_Analysis_Web_Apps.py
+++ b/Multiplex_Analysis_Web_Apps.py
@@ -1,19 +1,11 @@
 # Import relevant libraries
 import streamlit as st
-import platform_io
 from streamlit_javascript import st_javascript
-from st_pages import show_pages_from_config, add_indentation
-from streamlit_extras.app_logo import add_logo
-import streamlit_dataframe_editor as sde
 
 # Import relevant libraries
 import nidap_dashboard_lib as ndl   # Useful functions for dashboards connected to NIDAP
-
-# Function to determine whether we're on NIDAP
-def platform_is_nidap():
-    import numpy as np
-    import subprocess
-    return np.any(['nidap.nih.gov' in x for x in subprocess.run('conda config --show channels', shell=True, capture_output=True).stdout.decode().split('\n')[1:-1]])
+import app_top_of_page as top
+import streamlit_dataframe_editor as sde
 
 # Define the single, main function
 def main():
@@ -24,24 +16,9 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
+    # Run Top of Page (TOP) functions
+    st.session_state = top.top_of_page_reqs(st.session_state, newtab_flag=True)
 
-    # Get link for app to be opened in new tab and add link to docs
-    url = st_javascript("await fetch('').then(r => window.parent.location.href)")  # this single line is causing a repeatable "KeyError: 'platform'" that seems to not have any ill effects. This is fixed by putting this line after the "if 'platform' not in st.session_state:" block and "platform = st.session_state['platform']" line
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-        st.write('*[Open app in new tab]({}) (may only work in Chrome or Edge, not Firefox)*'.format(url))
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
-    # Initialize the platform object
-    if 'platform' not in st.session_state:
-        st.session_state['platform'] = platform_io.Platform(platform=('nidap' if platform_is_nidap() else 'local'))
-    
     intro_markdown = ndl.read_markdown_file('markdown/MAWA_WelcomePage.md')
     st.markdown(intro_markdown, unsafe_allow_html=True)
 

--- a/app_top_of_page.py
+++ b/app_top_of_page.py
@@ -26,7 +26,7 @@ def top_of_page_reqs(session_state, newtab_flag = False):
 
     # Sidebar organization
     with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
+        st.write('**:book: [Documentation](https://nidap.nih.gov/workspace/module/view/latest/ri.workshop.main.module.6b54d691-4d02-4f77-8acd-734f42e3eee0)**')
         if newtab_flag:
             # Get link for app to be opened in new tab and add link to docs
             # This line is causing a repeatable "KeyError: 'platform'" that seems 

--- a/app_top_of_page.py
+++ b/app_top_of_page.py
@@ -1,10 +1,12 @@
 import numpy as np
 import platform_io
 import subprocess
+import streamlit as st
+from st_pages import show_pages_from_config, add_indentation
 from streamlit_javascript import st_javascript
 from streamlit_extras.app_logo import add_logo
 
-def top_of_page_reqs(session_state):
+def top_of_page_reqs(session_state, newtab_flag = False):
     '''
     Top of the page requirements. These are the commands
     that are run at the top of the page that help maintain 
@@ -14,11 +16,25 @@ def top_of_page_reqs(session_state):
     # for key, val in session_state.items():
     #     if (not key.endswith('__do_not_persist')) and (not key.startswith('FormSubmitter:')):
     #         session_state[key] = val
+
     # Add Logo
-    # add_logo('app_images/mawa_logo-width315.png', height=150)
-    
-    # Get the URL of the current page, per https://discuss.streamlit.io/t/what-is-the-current-page-in-use-multipage-app/41898, which we've used before but keeping the reference here anyway. Remember something strange happens here, with the script running twice or the like and not picking up the session state fully or vice versa, so sometimes we see strange behavior as a result though it's usually not a bit deal. In this case I've taken care of it anyway below by resetting the index on default_df_contents2
-    session_state.curr_url = st_javascript("await fetch('').then(r => window.parent.location.href)")
+    add_logo('app_images/mawa_logo-width315.png', height=150)
+
+    # Apply pages order and indentation
+    add_indentation()
+    show_pages_from_config()
+
+    # Sidebar organization
+    with st.sidebar:
+        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
+        if newtab_flag:
+            # Get link for app to be opened in new tab and add link to docs
+            # This line is causing a repeatable "KeyError: 'platform'" that seems 
+            # not to have any ill effects. This is fixed by putting this line after the 
+            # "if 'platform' not in st.session_state:" block and "platform = st.session_state['platform']" line
+            url = st_javascript("await fetch('').then(r => window.parent.location.href)")  
+            st.write('*[Open app in new tab]({}) (may only work in Chrome or Edge, not Firefox)*'.format(url))
+
 
     # Check the platform
     session_state = check_for_platform(session_state)

--- a/pages/01_data_import_and_export.py
+++ b/pages/01_data_import_and_export.py
@@ -2,13 +2,11 @@
 This is the python script which produces the PHENOTYPING PAGE
 '''
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
-from streamlit_extras.app_logo import add_logo
-import streamlit_dataframe_editor as sde
 
 # Import relevant libraries
 import streamlit_utils
 import app_top_of_page as top
+import streamlit_dataframe_editor as sde
 
 def main():
     '''
@@ -22,19 +20,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     st.title('Data Import and Export')
 

--- a/pages/02_phenotyping.py
+++ b/pages/02_phenotyping.py
@@ -2,11 +2,8 @@
 This is the python script which produces the PHENOTYPING PAGE
 '''
 import os
-import time
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
-from streamlit_extras.add_vertical_space import add_vertical_space 
-from streamlit_extras.app_logo import add_logo
+from streamlit_extras.add_vertical_space import add_vertical_space
 import dataset_formats
 
 # Import relevant libraries
@@ -97,26 +94,13 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
+    # Run Top of Page (TOP) functions
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     if 'init' not in st.session_state:
         settings_yaml_file = 'config_files/OMAL_REEC.yml'
         # Initialize session_state values for streamlit processing
         st.session_state = ndl.init_session_state(st.session_state, settings_yaml_file)
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-        # st.button('Record Benchmarking', on_click=st.session_state.bc.save_run_to_csv)
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
-    # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
 
     st.header('Phenotyper\nNCATS-NCI-DMAP')
 

--- a/pages/03a_Tool_parameter_selection.py
+++ b/pages/03a_Tool_parameter_selection.py
@@ -1,8 +1,6 @@
 import os
 import yaml
 import streamlit as st
-from streamlit_extras.app_logo import add_logo
-from st_pages import show_pages_from_config, add_indentation
 import streamlit_utils
 
 # Import relevant libraries
@@ -222,19 +220,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Display page heading
     st.title('Tool parameter selection')

--- a/pages/03b_Run_workflow.py
+++ b/pages/03b_Run_workflow.py
@@ -6,9 +6,7 @@ import pprint
 import time_cell_interaction_lib as tci  # import the TIME library stored in time_cell_interaction_lib.py
 import time
 from pathlib import Path
-from streamlit_extras.app_logo import add_logo
 import streamlit_utils
-from st_pages import show_pages_from_config, add_indentation
 import app_top_of_page as top
 import streamlit_dataframe_editor as sde
 
@@ -20,19 +18,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Constant
     input_directory = os.path.join('.', 'input')

--- a/pages/03c_Display_individual_ROI_heatmaps.py
+++ b/pages/03c_Display_individual_ROI_heatmaps.py
@@ -2,8 +2,6 @@
 import os
 import streamlit as st
 import utils as utils
-from streamlit_extras.app_logo import add_logo
-from st_pages import show_pages_from_config, add_indentation
 
 import app_top_of_page as top
 import streamlit_dataframe_editor as sde
@@ -22,19 +20,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Display page heading
     st.title('Individual ROI heatmaps')

--- a/pages/03d_Display_average_heatmaps.py
+++ b/pages/03d_Display_average_heatmaps.py
@@ -1,8 +1,6 @@
 # Import relevant libraries
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
 import utils as utils
-from streamlit_extras.app_logo import add_logo
 import os
 
 import app_top_of_page as top
@@ -22,19 +20,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Display page heading
     st.title('Average heatmaps per slide')

--- a/pages/03e_Display_average_heatmaps_per_annotation.py
+++ b/pages/03e_Display_average_heatmaps_per_annotation.py
@@ -1,9 +1,7 @@
 # Import relevant libraries
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
 import annotations
 import os
-from streamlit_extras.app_logo import add_logo
 import streamlit_utils
 
 import app_top_of_page as top
@@ -17,19 +15,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Display page heading
     st.title('Annotation plots')

--- a/pages/03f_Display_ROI_P_values_overlaid_on_slides.py
+++ b/pages/03f_Display_ROI_P_values_overlaid_on_slides.py
@@ -1,9 +1,7 @@
 # Import relevant libraries
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
 import utils as utils
 import os
-from streamlit_extras.app_logo import add_logo
 
 import app_top_of_page as top
 import streamlit_dataframe_editor as sde
@@ -30,19 +28,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Display page heading
     st.title('ROI P values overlaid on slides')

--- a/pages/04a_Neighborhood Profiles.py
+++ b/pages/04a_Neighborhood Profiles.py
@@ -1,13 +1,8 @@
 '''
 This is the python script which produces the NEIGHBORHOOD PROFILES PAGE
 '''
-import time
-import pandas as pd
-from datetime import datetime
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
 from streamlit_extras.add_vertical_space import add_vertical_space 
-from streamlit_extras.app_logo import add_logo
 
 # Import relevant libraries
 import nidap_dashboard_lib as ndl   # Useful functions for dashboards connected to NIDAP
@@ -136,19 +131,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     if 'init' not in st.session_state:
         settings_yaml_file = 'config_files/OMAL_REEC.yml'

--- a/pages/04b_UMAP Analyzer.py
+++ b/pages/04b_UMAP Analyzer.py
@@ -1,6 +1,4 @@
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
-from streamlit_extras.app_logo import add_logo
 
 # Import relevant libraries
 import nidap_dashboard_lib as ndl   # Useful functions for dashboards connected to NIDAP
@@ -25,19 +23,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     if 'init' not in st.session_state:
         settings_yaml_file = 'config_files/OMAL_REEC.yml'

--- a/pages/04c_Clusters Analyzer.py
+++ b/pages/04c_Clusters Analyzer.py
@@ -1,7 +1,4 @@
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
-from streamlit_extras.app_logo import add_logo
-import time
 
 # Import relevant libraries
 import nidap_dashboard_lib as ndl   # Useful functions for dashboards connected to NIDAP
@@ -25,19 +22,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     if 'init' not in st.session_state:
         settings_yaml_file = 'config_files/OMAL_REEC.yml'

--- a/pages/multiaxial_gating.py
+++ b/pages/multiaxial_gating.py
@@ -2,17 +2,17 @@
 import pandas as pd
 import seaborn as sns
 import streamlit as st
-from st_pages import show_pages_from_config, add_indentation
 import plotly.graph_objects as go
 import os
 import dataset_formats
 import plotly.express as px
-import streamlit_dataframe_editor as sde
 import utils
 import matplotlib.pyplot as plt
 import numpy as np
-from streamlit_extras.app_logo import add_logo
+
+# Import relevant libraries
 import app_top_of_page as top
+import streamlit_dataframe_editor as sde
 
 # Function to load the data in a unified format
 def load_data(input_datafile_path, coord_units_in_microns, dataset_format):
@@ -224,19 +224,8 @@ def main():
     # Run streamlit-dataframe-editor library initialization tasks at the top of the page
     st.session_state = sde.initialize_session_state(st.session_state)
 
-    # Apply pages order and indentation
-    add_indentation()
-    show_pages_from_config()
-
-    # Sidebar organization
-    with st.sidebar:
-        st.write('**:book: [Documentation](https://ncats.github.io/multiplex-analysis-web-apps)**')
-
-    # Add logo to page
-    add_logo('app_images/mawa_logo-width315.png', height=150)
-
     # Run Top of Page (TOP) functions
-    st.session_state = top.check_for_platform(st.session_state)
+    st.session_state = top.top_of_page_reqs(st.session_state)
 
     # Set the default dataframes to be edited
     default_df_current_phenotype = pd.DataFrame(columns=['Column for filtering', 'Minimum value', 'Maximum value'])


### PR DESCRIPTION
We were overdue for a standard function that allows us to handle all of the required top of page (TOP) requirements. I made the adjustments to each page so that when there are changes to be made to the standard page setup, it can be done in one place. 

I then moved the URL from the GitHub location to the NIDAP documentation page.