### PR TITLE
Mainly fix bug causing patching in ROIs due to misaligned dataframe concatenation

### DIFF
--- a/dataset_formats.py
+++ b/dataset_formats.py
@@ -1331,8 +1331,8 @@ def potentially_apply_patching(df, input_datafile, roi_width, overlap, func_coor
         # Print the length of the new dataframe
         print('Length of duplicated dataframe: {}'.format(len(df)))
 
-    # Sort the data by slide and then by ROI
-    df = df.sort_values(by=['Slide ID', 'tag']).reset_index(drop=True)  # adding .reset_index(drop=True) to just *make sure* the SIP code in general doesn't assume the data index is already in sorted order
+    # # Sort the data by slide and then by ROI
+    # df = df.sort_values(by=['Slide ID', 'tag']).reset_index(drop=True)  # adding .reset_index(drop=True) to just *make sure* the SIP code in general doesn't assume the data index is already in sorted order
 
     return df
 
@@ -1359,8 +1359,8 @@ def delete_rois_with_single_coord(df):
     print('Dropping {} ROIs with valid objects that have only a single unique spatial coordinate'.format(len(rois_with_single_unique_coord)))
     df = df.loc[df['tag'].apply(lambda x: x not in rois_with_single_unique_coord), :]
 
-    # Add .reset_index(drop=True) to just *make sure* the SIP code in general doesn't assume the data index is already in sorted order
-    df = df.reset_index(drop=True)
+    # # Add .reset_index(drop=True) to just *make sure* the SIP code in general doesn't assume the data index is already in sorted order
+    # df = df.reset_index(drop=True)
 
     return df
 

--- a/pages/02_phenotyping.py
+++ b/pages/02_phenotyping.py
@@ -86,7 +86,7 @@ def marker_multiselect_callback():
 def make_sample_phenotype_assignments(csv_filename):
     # NEXT:
     #   * Make button below like in the Gater
-    #   * Call using csv_filename = 'sample_phenotype_assignments.csv'
+    #   * make_sample_phenotype_assignments(csv_filename='sample_phenotype_assignments.csv')
 
     # Import relevant library
     import pandas as pd
@@ -104,7 +104,7 @@ def make_sample_phenotype_assignments(csv_filename):
     df_to_which_to_update['phenotype'] = df_to_which_to_update['species_name_short'].apply(lambda species_name_short: assignments[species_name_short])
 
     # Update the official phenotype assignments dataframe with the dataframe to which to update it
-    st.session_state['pheno__de_phenotype_assignments'].update_editor_contents(df_to_which_to_update, reset_key=False)
+    st.session_state['pheno__de_phenotype_assignments'].update_editor_contents(df_to_which_to_update, reset_key=False, extra_functionality=data_editor_change_callback)
 
 def main():
     '''
@@ -249,6 +249,10 @@ def main():
             if 'pheno__de_phenotype_assignments' not in st.session_state:
                 st.session_state['pheno__de_phenotype_assignments'] = sde.DataframeEditor(df_name='pheno__df_phenotype_assignments', default_df_contents=bpl.init_pheno_assign(st.session_state.df))
             st.session_state['pheno__de_phenotype_assignments'].dataframe_editor(on_change=data_editor_change_callback, reset_data_editor_button_text='Reset phenotype assignments')  # note there is no return variable
+
+            # Allow a sample gating table to be loaded
+            st.button('Load sample gating table', on_click=make_sample_phenotype_assignments, kwargs={'csv_filename': 'sample_phenotype_assignments.csv'})
+
         else:
             st.dataframe(st.session_state.spec_summ, use_container_width=True)
 

--- a/pages/02_phenotyping.py
+++ b/pages/02_phenotyping.py
@@ -104,7 +104,7 @@ def make_sample_phenotype_assignments(csv_filename):
     df_to_which_to_update['phenotype'] = df_to_which_to_update['species_name_short'].apply(lambda species_name_short: assignments[species_name_short])
 
     # Update the official phenotype assignments dataframe with the dataframe to which to update it
-    st.session_state['pheno__de_phenotype_assignments'].update_editor_contents(df_to_which_to_update, reset_key=False, extra_functionality=data_editor_change_callback)
+    st.session_state['pheno__de_phenotype_assignments'].update_editor_contents(df_to_which_to_update, reset_key=False, additional_callback=data_editor_change_callback)
 
 def main():
     '''

--- a/pages/02_phenotyping.py
+++ b/pages/02_phenotyping.py
@@ -256,8 +256,8 @@ def main():
                 st.session_state['pheno__de_phenotype_assignments'] = sde.DataframeEditor(df_name='pheno__df_phenotype_assignments', default_df_contents=bpl.init_pheno_assign(st.session_state.df))
             st.session_state['pheno__de_phenotype_assignments'].dataframe_editor(on_change=data_editor_change_callback, reset_data_editor_button_text='Reset phenotype assignments')  # note there is no return variable
 
-            # Allow a sample gating table to be loaded
-            st.button('Load sample gating table', on_click=make_sample_phenotype_assignments, kwargs={'csv_filename': 'sample_phenotype_assignments.csv'})
+            # # Allow a sample gating table to be loaded
+            # st.button('Load sample gating table', on_click=make_sample_phenotype_assignments, kwargs={'csv_filename': 'sample_phenotype_assignments.csv'})
 
         else:
             st.dataframe(st.session_state.spec_summ, use_container_width=True)

--- a/pages/02_phenotyping.py
+++ b/pages/02_phenotyping.py
@@ -82,6 +82,30 @@ def marker_multiselect_callback():
     st.session_state.marker_names = st.session_state.marker_multi_sel
     st.session_state = ndl.set_phenotyping_elements(st.session_state, st.session_state.df_raw)
 
+# Allow sample phenotype assignments to be made for quick testing
+def make_sample_phenotype_assignments(csv_filename):
+    # NEXT:
+    #   * Make button below like in the Gater
+    #   * Call using csv_filename = 'sample_phenotype_assignments.csv'
+
+    # Import relevant library
+    import pandas as pd
+
+    # Get the current version of the phenotype assignments dataframe
+    df_to_which_to_update = st.session_state['pheno__de_phenotype_assignments'].reconstruct_edited_dataframe()
+
+    # Load in a dataframe containing the translations to make, from species_name_short to phenotype
+    df_to_assign = pd.read_csv(os.path.join('.', 'sample_phenotyping', csv_filename))
+
+    # Create a dictionary of these translations
+    assignments = dict(zip(df_to_assign['species_name_short'], df_to_assign['phenotype']))
+
+    # Use the translations dictionary to perform actual translation
+    df_to_which_to_update['phenotype'] = df_to_which_to_update['species_name_short'].apply(lambda species_name_short: assignments[species_name_short])
+
+    # Update the official phenotype assignments dataframe with the dataframe to which to update it
+    st.session_state['pheno__de_phenotype_assignments'].update_editor_contents(df_to_which_to_update, reset_key=False)
+
 def main():
     '''
     Main function for running the page

--- a/pages/02_phenotyping.py
+++ b/pages/02_phenotyping.py
@@ -161,6 +161,12 @@ def main():
             if (st.button('Load Multi-axial Gating Data')) & ('mg__df' in st.session_state):
                 st.session_state.bc.startTimer()
                 st.session_state = ndl.loadDataButton(st.session_state, st.session_state['mg__df'], 'Mutli-axial Gating', st.session_state.mg__input_datafile_filename[:-4])
+
+                # if st.button('DEBUG: Save data to pkl file'):
+                #     import pickle
+                #     with open('debug_data_from_gater.pkl', 'wb') as f:
+                #         pickle.dump(st.session_state['mg__df'], f)
+
                 st.session_state.bc.printElapsedTime(msg = f'Performing Phenotyping')
         st.session_state.bc.set_value_df('time_load_data', st.session_state.bc.elapsedTime())
 

--- a/pages/03a_Tool_parameter_selection.py
+++ b/pages/03a_Tool_parameter_selection.py
@@ -317,6 +317,11 @@ def main():
         set_session_state_key(settings, 'annotation', 'microns_per_integer_unit')
         set_session_state_key(settings, 'plotting', 'min_log_pval')
 
+    # if st.button('DEBUG: Save data to pkl file'):
+    #     import pickle
+    #     with open('debug_data.pkl', 'wb') as f:
+    #         pickle.dump([st.session_state['df'], st.session_state['mg__input_datafile_filename']], f)
+
     st.button(':arrow_right: Load relevant settings from Phenotyper', on_click=load_relevant_settings_from_phenotyper)
 
     # Logical divider

--- a/pages/multiaxial_gating.py
+++ b/pages/multiaxial_gating.py
@@ -588,6 +588,9 @@ def main():
             st.write('Augmented dataset sample:')
             st.dataframe(st.session_state['mg__df'].sample(5), hide_index=True)
 
+            # if st.button('Save dataset to `output` folder'):
+            #     st.session_state['mg__df'].to_csv('./output/saved_dataset.csv')
+
             # Get a list of all new phenotypes
             new_phenotypes = [column for column in st.session_state['mg__df'].columns if column.startswith('Phenotype ')]
 

--- a/pages/multiaxial_gating.py
+++ b/pages/multiaxial_gating.py
@@ -566,8 +566,8 @@ def main():
             # Output the dataframe holding the specifications for all phenotypes
             st.session_state['mg__de_phenotype_assignments'].dataframe_editor(reset_data_editor_button_text='Reset all phenotype definitions')
 
-            # Allow a sample gating table to be loaded
-            st.button('Load sample gating table', on_click=load_sample_gating_table, kwargs={'csv_filename': 'sample_gating_table.csv'})
+            # # Allow a sample gating table to be loaded
+            # st.button('Load sample gating table', on_click=load_sample_gating_table, kwargs={'csv_filename': 'sample_gating_table.csv'})
 
             # Generate the new dataset
             st.button(label=':star2: Append phenotype assignments to the dataset :star2:',

--- a/pages/multiaxial_gating.py
+++ b/pages/multiaxial_gating.py
@@ -254,6 +254,10 @@ def z_score_normalize(df, numeric_columns):
     # Return the transformed dataset
     return df_batch_normalized
 
+# Allow a sample gating table to be loaded for quick testing
+def load_sample_gating_table(csv_filename):
+    st.session_state['mg__de_phenotype_assignments'].update_editor_contents(pd.read_csv(os.path.join('.', 'sample_phenotyping', csv_filename)), reset_key=False)
+
 def main():
     '''
     Main function for running the page
@@ -561,6 +565,9 @@ def main():
 
             # Output the dataframe holding the specifications for all phenotypes
             st.session_state['mg__de_phenotype_assignments'].dataframe_editor(reset_data_editor_button_text='Reset all phenotype definitions')
+
+            # Allow a sample gating table to be loaded
+            st.button('Load sample gating table', on_click=load_sample_gating_table, kwargs={'csv_filename': 'sample_gating_table.csv'})
 
             # Generate the new dataset
             st.button(label=':star2: Append phenotype assignments to the dataset :star2:',

--- a/sample_phenotyping/sample_gating_table.csv
+++ b/sample_phenotyping/sample_gating_table.csv
@@ -1,0 +1,6 @@
+﻿Phenotype,DAPI-01 Cell Intensity [[min]],DAPI-01 Cell Intensity [[max]],Ki67 Cell Intensity [[min]],Ki67 Cell Intensity [[max]],MHC II Cell Intensity [[min]],MHC II Cell Intensity [[max]],Cell Area (µm²) [[min]],Cell Area (µm²) [[max]],CD4 Cell Intensity [[min]],CD4 Cell Intensity [[max]]
+ki67 pos,1.04,10.957334454691388,0.01,3.249432855327681,,,,,,
+mhcii low,1.04,10.957334454691388,,,-1.7094430773299267,-0.04,0.15,15.017737047617352,,
+mhcii high,1.04,10.957334454691388,,,-0.02,100,0.15,15.017737047617352,,
+cd4 low,,,,,,,,,-2.608387899627314,0.52
+cd4 high,,,,,,,,,0.52,200

--- a/sample_phenotyping/sample_phenotype_assignments.csv
+++ b/sample_phenotyping/sample_phenotype_assignments.csv
@@ -1,0 +1,13 @@
+﻿species_name_short,phenotype,species_name_long,species_count,species_percent
+cd4 low+,otherr,ki67 pos- mhcii low- mhcii high- cd4 low+ cd4 high-,223731,62.02
+cd4 high+,otherr,ki67 pos- mhcii low- mhcii high- cd4 low- cd4 high+,99090,27.47
+ki67 pos+ cd4 low+,ki67 poss,ki67 pos+ mhcii low- mhcii high- cd4 low+ cd4 high-,8629,2.39
+ki67 pos+ cd4 high+,ki67 poss,ki67 pos+ mhcii low- mhcii high- cd4 low- cd4 high+,6506,1.8
+ki67 pos+ mhcii low+ cd4 low+,ki67 poss,ki67 pos+ mhcii low+ mhcii high- cd4 low+ cd4 high-,3895,1.08
+ki67 pos+ mhcii high+ cd4 high+,otherr,ki67 pos+ mhcii low- mhcii high+ cd4 low- cd4 high+,3574,0.99
+ki67 pos+ mhcii high+ cd4 low+,mhcii highh,ki67 pos+ mhcii low- mhcii high+ cd4 low+ cd4 high-,3488,0.97
+ki67 pos+ mhcii low+ cd4 high+,otherr,ki67 pos+ mhcii low+ mhcii high- cd4 low- cd4 high+,2653,0.74
+mhcii low+ cd4 low+,mhcii loww,ki67 pos- mhcii low+ mhcii high- cd4 low+ cd4 high-,2534,0.7
+mhcii high+ cd4 high+,mhcii highh,ki67 pos- mhcii low- mhcii high+ cd4 low- cd4 high+,2402,0.67
+mhcii high+ cd4 low+,mhcii highh,ki67 pos- mhcii low- mhcii high+ cd4 low+ cd4 high-,2312,0.64
+mhcii low+ cd4 high+,mhcii loww,ki67 pos- mhcii low+ mhcii high- cd4 low- cd4 high+,1913,0.53

--- a/streamlit_dataframe_editor.py
+++ b/streamlit_dataframe_editor.py
@@ -123,13 +123,13 @@ class DataframeEditor:
         self.default_df_contents = cast_column_labels_to_strings(default_df_contents)
         self.reset_dataframe_content()
 
-    def reset_dataframe_content(self, extra_functionality=None):
+    def reset_dataframe_content(self, additional_callback=None):
         '''
         Initialize the editor contents to its default dataframe
         '''
-        self.update_editor_contents(new_df_contents=self.default_df_contents, extra_functionality=extra_functionality)  # reset_key must = True (the default) here or else the resetting will not happen per nuances of Streamlit, due to the desired dataframe contents being the same as they once were with the same key I believe
+        self.update_editor_contents(new_df_contents=self.default_df_contents, additional_callback=additional_callback)  # reset_key must = True (the default) here or else the resetting will not happen per nuances of Streamlit, due to the desired dataframe contents being the same as they once were with the same key I believe
 
-    def update_editor_contents(self, new_df_contents, reset_key=True, extra_functionality=None):
+    def update_editor_contents(self, new_df_contents, reset_key=True, additional_callback=None):
         '''
         Set the dataframe in the data editor to specific values robustly
         Note reset_key=True has some flicker but is necessary in case the data editor contents are ever the same, in which case they wouldn't update. So reset_key=False may lead to non-updates, but no flicker, and is the right option for e.g. leaving and coming back to the page containing the data editor as long as the contents were not expected to have changed in the interim, so there's no need to force a refresh using reset_key=True.
@@ -145,8 +145,8 @@ class DataframeEditor:
             st.session_state[df_name + '_key'] = df_name + '_' + get_random_integer() + '__do_not_persist'  # not strictly necessary to do every time, though it is in the case where the new data is exactly the same as the original data, so we may as well do it every time
 
         # Allow extra functionality to be run if the data editor contents are programmatically changed
-        if extra_functionality is not None:
-            extra_functionality()
+        if additional_callback is not None:
+            additional_callback()
 
     def reconstruct_edited_dataframe(self):
         '''
@@ -179,4 +179,4 @@ class DataframeEditor:
 
         # Create a button to reset the data in the data editor
         if reset_data_editor_button:
-            st.button(reset_data_editor_button_text, on_click=self.reset_dataframe_content, key=(df_name + '_button__do_not_persist'), kwargs={'extra_functionality': on_change})
+            st.button(reset_data_editor_button_text, on_click=self.reset_dataframe_content, key=(df_name + '_button__do_not_persist'), kwargs={'additional_callback': on_change})

--- a/streamlit_dataframe_editor.py
+++ b/streamlit_dataframe_editor.py
@@ -123,13 +123,13 @@ class DataframeEditor:
         self.default_df_contents = cast_column_labels_to_strings(default_df_contents)
         self.reset_dataframe_content()
 
-    def reset_dataframe_content(self):
+    def reset_dataframe_content(self, extra_functionality=None):
         '''
         Initialize the editor contents to its default dataframe
         '''
-        self.update_editor_contents(new_df_contents=self.default_df_contents)  # reset_key must = True (the default) here or else the resetting will not happen per nuances of Streamlit, due to the desired dataframe contents being the same as they once were with the same key I believe
+        self.update_editor_contents(new_df_contents=self.default_df_contents, extra_functionality=extra_functionality)  # reset_key must = True (the default) here or else the resetting will not happen per nuances of Streamlit, due to the desired dataframe contents being the same as they once were with the same key I believe
 
-    def update_editor_contents(self, new_df_contents, reset_key=True):
+    def update_editor_contents(self, new_df_contents, reset_key=True, extra_functionality=None):
         '''
         Set the dataframe in the data editor to specific values robustly
         Note reset_key=True has some flicker but is necessary in case the data editor contents are ever the same, in which case they wouldn't update. So reset_key=False may lead to non-updates, but no flicker, and is the right option for e.g. leaving and coming back to the page containing the data editor as long as the contents were not expected to have changed in the interim, so there's no need to force a refresh using reset_key=True.
@@ -143,6 +143,10 @@ class DataframeEditor:
         # This step causes brief flashing of the dataframe so it's best to not run this unless required. A good time to not run this is when a dataframe is reloaded after leaving and coming back to the page it's on
         if reset_key:
             st.session_state[df_name + '_key'] = df_name + '_' + get_random_integer() + '__do_not_persist'  # not strictly necessary to do every time, though it is in the case where the new data is exactly the same as the original data, so we may as well do it every time
+
+        # Allow extra functionality to be run if the data editor contents are programmatically changed
+        if extra_functionality is not None:
+            extra_functionality()
 
     def reconstruct_edited_dataframe(self):
         '''
@@ -175,4 +179,4 @@ class DataframeEditor:
 
         # Create a button to reset the data in the data editor
         if reset_data_editor_button:
-            st.button(reset_data_editor_button_text, on_click=self.reset_dataframe_content, key=(df_name + '_button__do_not_persist'))
+            st.button(reset_data_editor_button_text, on_click=self.reset_dataframe_content, key=(df_name + '_button__do_not_persist'), kwargs={'extra_functionality': on_change})


### PR DESCRIPTION
Fix bug causing patching in ROIs due to misaligned dataframe concatenation; add hidden functionality to load sample phenotypes; add to streamlit dataframe editor to run default callbacks at the expected times.

Closes #70 