### PR TITLE
Three bug fixes

### DIFF
--- a/pages2/datafile_format_unifier.py
+++ b/pages2/datafile_format_unifier.py
@@ -705,7 +705,7 @@ def main():
         st.header('Sample of unified dataframe')
         resample_dataframe = st.button('Refresh dataframe sample')
         if ('sampled_df' not in st.session_state) or resample_dataframe or show_dataframe_updates:
-            sampled_df = df.sample(100).sort_index()
+            sampled_df = utils.sample_df_without_replacement_by_number(df=df, n=100).sort_index()
             st.session_state['sampled_df'] = sampled_df
         sampled_df = st.session_state['sampled_df']
         st.write(sampled_df)

--- a/pages2/multiaxial_gating.py
+++ b/pages2/multiaxial_gating.py
@@ -980,7 +980,7 @@ def main():
 
         # Print out a five-row sample of the main dataframe
         st.write('Augmented dataset sample:')
-        st.dataframe(st.session_state['mg__df'].sample(5), hide_index=True)
+        st.dataframe(utils.sample_df_without_replacement_by_number(df=st.session_state['mg__df'], n=5), hide_index=True)
 
         # if st.button('Save dataset to `output` folder'):
         #     st.session_state['mg__df'].to_csv('./output/saved_dataset.csv')

--- a/pages2/open_file.py
+++ b/pages2/open_file.py
@@ -163,7 +163,7 @@ def main():
     st.header('Dataframe sample')
     resample_dataframe = st.button('Refresh dataframe sample')
     if ('opener__sampled_df' not in st.session_state) or resample_dataframe or show_dataframe_updates:
-        st.session_state['opener__sampled_df'] = df.sample(min(num_rows_to_sample, len(df))).sort_index()
+        st.session_state['opener__sampled_df'] = utils.sample_df_without_replacement_by_number(df=df, n=num_rows_to_sample).sort_index()
     st.write(st.session_state['opener__sampled_df'])
 
 # Run the main function

--- a/pages2/robust_scatter_plotter.py
+++ b/pages2/robust_scatter_plotter.py
@@ -97,7 +97,7 @@ def draw_scatter_plot_with_options():
             df = st.session_state['df']
 
         # Store columns of certain types
-        if ('rsp__categorical_columns' not in st.session_state) or input_dataset_has_changed:
+        if ('rsp__categorical_columns' not in st.session_state) or input_dataset_has_changed or st.button('Re-extract columns from dataset'):
             max_num_unique_values = 1000
             categorical_columns = []
             for col in df.select_dtypes(include=('category', 'object')).columns:
@@ -113,7 +113,7 @@ def draw_scatter_plot_with_options():
         # Choose a column to plot
         if ('rsp__column_to_plot' not in st.session_state) or input_dataset_has_changed:
             st.session_state['rsp__column_to_plot'] = categorical_columns[0]
-        column_to_plot = st.selectbox('Select a column by which to color the points:', categorical_columns, key='rsp__column_to_plot')
+        column_to_plot = st.selectbox('Select a column by which to color the points:', categorical_columns, key='rsp__column_to_plot', help='If you don\'t see the column you want, you may need to re-extract the columns from the dataset using the button above.')
         column_to_plot_has_changed = ('rsp__column_to_plot_prev' not in st.session_state) or (st.session_state['rsp__column_to_plot_prev'] != column_to_plot) or input_dataset_has_changed
         st.session_state['rsp__column_to_plot_prev'] = column_to_plot
 

--- a/radial_profiles.py
+++ b/radial_profiles.py
@@ -19,7 +19,7 @@ def common_suffix(ser):
 # Create a function to check for duplicate columns
 def has_duplicate_columns(df, sample_size=1000):
     print('NOTE: Sampling is being performed, so if this returns True, consider increasing the sample_size parameter (or manually check for duplicates). If it returns False, you know that there are no duplicate columns in the DataFrame and do not need to stress about the sampling.')
-    df = df.sample(n=sample_size)
+    df = utils.sample_df_without_replacement_by_number(df=df, n=sample_size)
     df_transposed = df.T
     df_deduplicated = df_transposed.drop_duplicates().T
     return len(df.columns) != len(df_deduplicated.columns)  # if they're the same length (has_duplicate_columns() returns False), you know there are no duplicate columns

--- a/time_cell_interaction_lib.py
+++ b/time_cell_interaction_lib.py
@@ -1824,7 +1824,7 @@ class TIMECellInteraction:
                         dpi=dpi,
                         plots_dir=savedir,
                         plot_real_data=plot_real_data,
-                        entity_name=slide_name,
+                        entity_name=slide_name.replace(' ', '_'),
                         img_file_suffix=img_file_suffix,
                         entity=entity,
                         entity_index=-1,
@@ -2242,7 +2242,7 @@ class TIMECellInteraction:
                         dpi=settings__plotting__pval_dpi,
                         plots_dir=plots_dir,
                         plot_real_data=plot_real_data,
-                        entity_name=entity_name,
+                        entity_name=entity_name.replace(' ', '_'),
                         img_file_suffix='',
                         entity=entity,
                         entity_index=-1,
@@ -4102,7 +4102,7 @@ def plot_single_density_pvals(argument_tuple):
 
     # Define the ROI-specific variables from the main df_density_pvals_arrays parameter
     log_dens_pvals_arr = df_density_pvals_arrays.loc[entity_index, 'log_dens_pvals_arr']
-    entity_name = df_density_pvals_arrays.loc[entity_index, 'roi_name']
+    entity_name = df_density_pvals_arrays.loc[entity_index, 'roi_name'].replace(' ', '_')  # this is probably the place to replace spaces with underscores
     entity = 'roi'
 
     # Plot the heatmaps for the current set of data
@@ -4143,7 +4143,7 @@ def plot_single_roi(args_as_single_tuple):
 
     # Assign the data for the current ROI to useful variables
     roi_name = df_data_by_roi.loc[roi_index, 'unique_roi']  # df_data_by_roi.loc[roi_index, 'roi_name']
-    roi_fig_filename = 'roi_plot_{}_{}.{}'.format(roi_name, roi_index, save_image_ext)
+    roi_fig_filename = 'roi_plot_{}_{}.{}'.format(roi_name.replace(' ', '_'), roi_index, save_image_ext)
     roi_fig_pathname = os.path.join(savedir, roi_fig_filename)
 
     # If the image file doesn't already exist...

--- a/utils.py
+++ b/utils.py
@@ -1266,3 +1266,8 @@ def get_categorical_columns_including_numeric(df, max_num_unique_values=1000):
         if df[col].nunique() <= max_num_unique_values:
             categorical_columns.append(col)
     return categorical_columns
+
+
+def sample_df_without_replacement_by_number(df, n, seed=None):
+    n = min(n, len(df))
+    return df.sample(n=n, replace=False, random_state=seed)


### PR DESCRIPTION
Fix for user sampling without replacement issue when dataset is small

Revealed but in SIT when ROIs/slides have spaces in their names, so replaced them with underscores (I had done that in some of the images)

Allow user to manually re-extract columns in the scatter plotter as we had noticed previously and as I saw again now