### PR TITLE
Allow user to download slide-level (averaged over ROIs) heatmap data.

### DIFF
--- a/pages2/Display_average_heatmaps.py
+++ b/pages2/Display_average_heatmaps.py
@@ -71,7 +71,7 @@ def main():
             # Check if directory exists and find CSV files
             if os.path.exists(heatmap_data_dir):
                 csv_files = [f for f in os.listdir(heatmap_data_dir) if f.endswith('_log_dens_pvals.csv')]
-                
+
                 if not csv_files:
                     st.warning('No heatmap data files found. Please select this option in the tool parameter selection.', icon='⚠️')
                 else:
@@ -79,7 +79,7 @@ def main():
                     def create_zip():
                         import zipfile
                         import io
-                        
+
                         zip_buffer = io.BytesIO()
                         with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
                             for csv_file in csv_files:

--- a/pages2/Display_average_heatmaps.py
+++ b/pages2/Display_average_heatmaps.py
@@ -63,6 +63,39 @@ def main():
             slide_suffix = ('' if st.session_state['display_slide_patching'] == 'not patched' else '_patched')
             st.image(df_paths_per_slide.loc[st.session_state['slide_name_to_visualize'], 'slide{}'.format(slide_suffix)])
 
+        # If we're requesting to save the heatmap data, then there should be files that end with "_log_dens_pvals.csv" in ('.', 'output', 'images', 'dens_pvals_per_slide'). If so, then create a download button that finds all such files, zips them up, and allows the user to download them. Allow the user to download all data for all slides rather than being specific to just the currently selected slide.
+        if st.session_state['sit__used_settings']['plotting']['save_heatmap_data']:
+            # Get the directory where the heatmap data is stored.
+            heatmap_data_dir = os.path.join('.', 'output', 'images', 'dens_pvals_per_slide')
+
+            # Check if directory exists and find CSV files
+            if os.path.exists(heatmap_data_dir):
+                csv_files = [f for f in os.listdir(heatmap_data_dir) if f.endswith('_log_dens_pvals.csv')]
+                
+                if not csv_files:
+                    st.warning('No heatmap data files found. Please select this option in the tool parameter selection.', icon='⚠️')
+                else:
+                    # Function to create zip file only when needed
+                    def create_zip():
+                        import zipfile
+                        import io
+                        
+                        zip_buffer = io.BytesIO()
+                        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+                            for csv_file in csv_files:
+                                file_path = os.path.join(heatmap_data_dir, csv_file)
+                                zip_file.write(file_path, csv_file)
+                        return zip_buffer.getvalue()
+
+                    # Create download button that calls create_zip() only when pressed
+                    st.download_button(
+                        label=f'Download heatmap data ({len(csv_files)} files)',
+                        data=create_zip(),
+                        file_name='heatmap_data.zip',
+                        mime='application/zip'
+                    )
+            else:
+                st.warning('Heatmap data directory not found. Please run the analysis first.', icon='⚠️')
     else:
         st.warning('At least one of the two sets of per-slide plots does not exist; please run all per-slide components of the workflow on the "Run workflow" page', icon='⚠️')
 

--- a/pages2/Run_workflow.py
+++ b/pages2/Run_workflow.py
@@ -171,7 +171,8 @@ def main():
                 st.write('**:sparkles: {}...**'.format(block_names[iblock]))
                 slices.average_dens_pvals_over_rois_for_each_slide(
                     weight_rois_by_num_valid_centers=st.session_state['sit__used_settings']['plotting']['weight_rois_by_num_valid_centers'],
-                    input_datafile=st.session_state['input_metadata']['datafile_path']  # this is just needed to get the input data filename to save to disk along with the df_log_dens_pvals_arr_per_slide for later read-in by the correlation analyzer
+                    input_datafile=st.session_state['input_metadata']['datafile_path'],  # this is just needed to get the input data filename to save to disk along with the df_log_dens_pvals_arr_per_slide for later read-in by the correlation analyzer
+                    save_heatmap_data=st.session_state['sit__used_settings']['plotting']['save_heatmap_data'],
                 )
 
             # Plot the ROIs on each slide

--- a/pages2/Tool_parameter_selection.py
+++ b/pages2/Tool_parameter_selection.py
@@ -395,6 +395,7 @@ def main():
         if 'settings__annotation__microns_per_integer_unit' not in st.session_state:
             st.session_state['settings__annotation__microns_per_integer_unit'] = 0.25
         st.session_state['settings__plotting__min_log_pval'] = -50
+        st.session_state['settings__plotting__save_slide_averaged_heatmap_data'] = False
 
     # Allow the user to select an existing parameter file
     columns = st.columns(2)
@@ -468,6 +469,7 @@ def main():
         st.number_input('Number of nearest neighbors:', min_value=0, key='settings__analysis__n_neighs', disabled=st.session_state['analysis_n_neighs_is_disabled'])
         st.number_input('Minimum number of valid centers:', min_value=1, key='settings__analysis__min_num_valid_centers', help='Valid centers are defined as cells inside an analysis radius from the ROI edges. If a particular phenotype in a ROI has fewer than the minimum number of valid cells, it is excluded from downstream analysis as a center species (not as a neighbor species). I.e., the user may want to define a minimum sample size.')
         st.checkbox('For just the "Display average heatmaps" page, weight by the number of valid centers', key='settings__analysis__weight_by_num_valid_centers', help='This refers to the averaging performed on the "Display average heatmaps" page, in which the rows in the density P value heatmaps for each ROI are weighted by the number of valid centers in each row. (This *is not* center-neighbor symmetric because in a given analysis, the number valid neighbors is the total number of neighbors in the ROI whereas the number of valid centers is the number of centers within an analysis radius buffer from the ROI edge.) This has no effect on the averaging done per annotation region type, i.e., the averaging performed on the "Display average heatmaps per annotation" page, in which the ROIs are uniformly weighted depending on the weighting method selected on that page, for each annotation region type. (This *is* center-neighbor symmetric because the same weight is assigned to all the center-neighbor pairs for each ROI.) So the averaging done on these two pages is fundamentally different, even aside from annotations being involved.')
+        st.checkbox('For just the "Display average heatmaps" page, save the slide-averaged density P value heatmap data', key='settings__plotting__save_slide_averaged_heatmap_data', help='This saves the slide-averaged density P value heatmap data to the output directory, which can be used for further analysis or visualization.')
 
         # Input of clipping information
         st.write('Clipping range of the log (base 10) density P values:')
@@ -510,6 +512,7 @@ def main():
     orig_settings['analysis']['images_to_analyze'] = st.session_state['settings__analysis__images_to_analyze']
     orig_settings['analysis']['phenotypes_to_analyze'] = st.session_state['settings__analysis__phenotypes_to_analyze']
     orig_settings['plotting']['min_log_pval'] = st.session_state['settings__plotting__min_log_pval']
+    orig_settings['plotting']['save_heatmap_data'] = st.session_state['settings__plotting__save_slide_averaged_heatmap_data']
 
     # Save the currently selected settings, in the original API format, to memory
     st.session_state['sit__workflow_settings'] = orig_settings

--- a/time_cell_interaction_lib.py
+++ b/time_cell_interaction_lib.py
@@ -4266,12 +4266,16 @@ def generate_dens_pvals_array_for_roi(args_as_single_tuple):
     make_pickle({'roi_name': roi_name, 'log_dens_pvals_arr': log_dens_pvals_arr, 'num_valid_centers': num_valid_centers, 'centers_neighbors_arr': roi_center_neighbor_holder}, pickle_dir, pickle_file)
 
 
-def plot_density_pvals_simple(log_dens_pvals_arr, log_pval_range, figsize, dpi, plots_dir, plot_real_data, entity_name, img_file_suffix, entity, entity_index, all_species_names, title_suffix=''):
+def plot_density_pvals_simple(log_dens_pvals_arr, log_pval_range, figsize, dpi, plots_dir, plot_real_data, entity_name, img_file_suffix, entity, entity_index, all_species_names, title_suffix='', replace_characters=True):
 
     # Import relevant libraries
     import matplotlib.pyplot as plt
     import seaborn as sns
     import os
+
+    # Get rid of the "(plus)" and "(dash)" characters in the species names, if requested.
+    if replace_characters:
+        all_species_names = [x.replace('(plus)', '+').replace('(dash)', '-') for x in all_species_names]
 
     # Determine the number of slices from the main array to plot
     nslices = log_dens_pvals_arr.shape[3]

--- a/time_cell_interaction_lib.py
+++ b/time_cell_interaction_lib.py
@@ -1,5 +1,6 @@
 import utils
 import new_phenotyping_lib
+import pandas as pd
 
 save_image_ext = 'jpg'
 # save_image_ext = 'png'
@@ -1686,7 +1687,7 @@ class TIMECellInteraction:
         return df_data_by_roi
 
 
-    def average_dens_pvals_over_rois_for_each_slide(self, figsize=(10, 4), dpi=100, img_file_suffix='', plot_real_data=True, do_plotting=True, weight_rois_by_num_valid_centers=False, input_datafile='../data/dummy_txt_or_csv.csv'):
+    def average_dens_pvals_over_rois_for_each_slide(self, figsize=(10, 4), dpi=100, img_file_suffix='', plot_real_data=True, do_plotting=True, weight_rois_by_num_valid_centers=False, input_datafile='../data/dummy_txt_or_csv.csv', save_heatmap_data=False):
         """Average the P values over all ROIs for each slide. Note I have confirmed that this yields the same results as a non-weighted version of the original method.
 
         Args:
@@ -1829,7 +1830,8 @@ class TIMECellInteraction:
                         entity=entity,
                         entity_index=-1,
                         all_species_names=all_species_names,
-                        title_suffix=title_suffix
+                        title_suffix=title_suffix,
+                        save_heatmap_data=save_heatmap_data,
                     )
                 else:
                     print('Not plotting P values for slide {} averaged over all its ROIs with valid P value data, because there are no ROIs with valid P value data'.format(slide_name))
@@ -4266,7 +4268,7 @@ def generate_dens_pvals_array_for_roi(args_as_single_tuple):
     make_pickle({'roi_name': roi_name, 'log_dens_pvals_arr': log_dens_pvals_arr, 'num_valid_centers': num_valid_centers, 'centers_neighbors_arr': roi_center_neighbor_holder}, pickle_dir, pickle_file)
 
 
-def plot_density_pvals_simple(log_dens_pvals_arr, log_pval_range, figsize, dpi, plots_dir, plot_real_data, entity_name, img_file_suffix, entity, entity_index, all_species_names, title_suffix='', replace_characters=True):
+def plot_density_pvals_simple(log_dens_pvals_arr, log_pval_range, figsize, dpi, plots_dir, plot_real_data, entity_name, img_file_suffix, entity, entity_index, all_species_names, title_suffix='', replace_characters=True, save_heatmap_data=False):
 
     # Import relevant libraries
     import matplotlib.pyplot as plt
@@ -4320,6 +4322,16 @@ def plot_density_pvals_simple(log_dens_pvals_arr, log_pval_range, figsize, dpi, 
 
         # Save the figure to disk
         fig.savefig(filename, dpi=dpi, bbox_inches='tight')
+
+        # Optionally save the heatmap data to CSV (one CSV for each of left and right P values) with the same filename except with a .csv extension and "left" or "right" appropriately indicated in the CSV filenames.The row and column names should both correspond to all_species_names. The data in the CSV file should be in the same order as the heatmap so e.g. the top-right cell in the heatmap corresponds to the first row and last column in the CSV file.
+        if save_heatmap_data:
+            # Save the left log density P values to a CSV file.
+            left_log_dens_pvals_df = pd.DataFrame(log_dens_pvals_arr[:, :, 0, islice], index=all_species_names, columns=all_species_names)
+            left_log_dens_pvals_df.to_csv(filename.replace(f'.{save_image_ext}', '-left_log_dens_pvals.csv'))
+
+            # Save the right log density P values to a CSV file
+            right_log_dens_pvals_df = pd.DataFrame(log_dens_pvals_arr[:, :, 1, islice], index=all_species_names, columns=all_species_names)
+            right_log_dens_pvals_df.to_csv(filename.replace(f'.{save_image_ext}', '-right_log_dens_pvals.csv'))
 
     # Close the figure
     plt.close(fig)

--- a/utils.py
+++ b/utils.py
@@ -139,6 +139,9 @@ def get_paths_for_slides():
     slides_listing = [y for y in slides_listing if '-patched.' not in y]
     heatmaps_listing = os.listdir(heatmaps_dir)
 
+    # Filter out CSV files from heatmaps listing
+    heatmaps_listing = [y for y in heatmaps_listing if not y.lower().endswith('.csv')]
+
     # Initialize an empty Pandas dataframe holding the full image pathnames where the index is the core slide name
     file_extension = os.path.splitext(slides_listing[0])[1]
     df_paths = pd.DataFrame([os.path.splitext(x)[0] for x in slides_listing], columns=['slide_name']).set_index('slide_name')


### PR DESCRIPTION
At the same time, get rid of the "(plus)" and "(dash)" characters in the species names in the heatmap plots.

Note that this download functionality works locally but need to test on NIDAP.